### PR TITLE
rad2deg method for consistency and future use

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Pose2PoseTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Pose2PoseTest.java
@@ -29,6 +29,10 @@ public class Pose2PoseTest extends LinearOpMode {
         return deg * Math.PI / 180;
     }
 
+    private static double rad2deg(double rad) {
+        return rad * 180 / Math.PI;
+    }
+
     @SuppressLint("DefaultLocale") // Android Lint should ignore warnings for DefaultLocale
     @Override
     public void runOpMode() {
@@ -136,7 +140,7 @@ public class Pose2PoseTest extends LinearOpMode {
             telemetry.addData("x", p.x()); // Print y attribute of pose
             telemetry.addData("y", p.y()); // Print x attribute of pose
             telemetry.addData("heading (rad)", p.heading()); // Print the heading in radians
-            telemetry.addData("heading (deg)", p.heading() * 180 / Math.PI); // Print the heading in degrees
+            telemetry.addData("heading (deg)", rad2deg(p.heading())); // Print the heading in degrees
             telemetry.addLine(); // Add space for format
             // Print the loop time for via ticks
             telemetry.addLine(String.format("Loop time: %.2fms", ticker.getAvg() * 1000));
@@ -148,7 +152,7 @@ public class Pose2PoseTest extends LinearOpMode {
             telemetry.addData("x", tracker.getPose().x()); // Print x attribute for pose
             telemetry.addData("y", tracker.getPose().y()); // Print y attribute for pose
             telemetry.addData("heading (rad)", tracker.getPose().heading()); // Print the heading in radians
-            telemetry.addData("heading (deg)", tracker.getPose().heading() * 180 / Math.PI); // Print the heading in degrees
+            telemetry.addData("heading (deg)", rad2deg(tracker.getPose().heading())); // Print the heading in degrees
             telemetry.addLine(String.format("While running: %.2fms per loop", ticker.getAvg() * 1000));
             telemetry.update();
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Pose2PoseTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Pose2PoseTest.java
@@ -21,17 +21,9 @@ import org.firstinspires.ftc.teamcode.utilities.LoopStopwatch;
 @Autonomous // Appear on the autonomous drop down
 public class Pose2PoseTest extends LinearOpMode {
     public static final double ACCEPT_DIST = .25; // inch. euclidean distance
-    public static final double ACCEPT_TURN = deg2rad(5);
+    public static final double ACCEPT_TURN = Math.toRadians(5);
     // power biases
     public static final Motion.Calibrate CALIBRATION = new Motion.Calibrate(1.0, 1.33, 1.0); // Calibration factors for strafe, forward, and turn.
-
-    private static double deg2rad(double deg) {
-        return deg * Math.PI / 180;
-    }
-
-    private static double rad2deg(double rad) {
-        return rad * 180 / Math.PI;
-    }
 
     @SuppressLint("DefaultLocale") // Android Lint should ignore warnings for DefaultLocale
     @Override
@@ -40,7 +32,7 @@ public class Pose2PoseTest extends LinearOpMode {
         EncoderTracking tracker = new EncoderTracking(hardware);
         // Pose targets to go thru
         Pose[] targets = {
-                new Pose(48, 0, deg2rad(90))
+                new Pose(48, 0, Math.toRadians(90))
         };
         int targetIndex = 0; // Total poses in the set
         ElapsedTime timer = new ElapsedTime(); // Set timer object to reference the ElapsedTime object
@@ -140,7 +132,7 @@ public class Pose2PoseTest extends LinearOpMode {
             telemetry.addData("x", p.x()); // Print y attribute of pose
             telemetry.addData("y", p.y()); // Print x attribute of pose
             telemetry.addData("heading (rad)", p.heading()); // Print the heading in radians
-            telemetry.addData("heading (deg)", rad2deg(p.heading())); // Print the heading in degrees
+            telemetry.addData("heading (deg)", Math.toDegrees(p.heading())); // Print the heading in degrees
             telemetry.addLine(); // Add space for format
             // Print the loop time for via ticks
             telemetry.addLine(String.format("Loop time: %.2fms", ticker.getAvg() * 1000));
@@ -152,7 +144,7 @@ public class Pose2PoseTest extends LinearOpMode {
             telemetry.addData("x", tracker.getPose().x()); // Print x attribute for pose
             telemetry.addData("y", tracker.getPose().y()); // Print y attribute for pose
             telemetry.addData("heading (rad)", tracker.getPose().heading()); // Print the heading in radians
-            telemetry.addData("heading (deg)", rad2deg(tracker.getPose().heading())); // Print the heading in degrees
+            telemetry.addData("heading (deg)", Math.toDegrees(tracker.getPose().heading())); // Print the heading in degrees
             telemetry.addLine(String.format("While running: %.2fms per loop", ticker.getAvg() * 1000));
             telemetry.update();
         }


### PR DESCRIPTION
### Background
- PR Type: `Proposal`
- Source: `origin/localization-test`
- Destination: `origin/localization`
- Severity: `Low`

### Purpose
Code consistency, not having to convert using `180 / Math.PI` every time.

### YAP
As I was reviewing and commenting code, I found that in multiple instances the same arithmetic was being used to convert from radians to degrees over and over. I know there is a "deg2rad" function already implemented, and that this is very minor, but it feels out of place to have a deg2rad function but always do the conversions for the vice versa


`git clone` is `git clown` on my machine 🤡